### PR TITLE
Gmp 404

### DIFF
--- a/src/htdocs/js/geomag/MagnetometerOrdinatesView.js
+++ b/src/htdocs/js/geomag/MagnetometerOrdinatesView.js
@@ -163,7 +163,7 @@ define([
 				Format.rawNanoteslas(calculator.pierCorrection());
 		this._scaleValue.innerHTML = [
 				'Ordinate Mean D is calculated using ',
-				'<code>(Corrected F * scaleValue / 60)</code>',
+				'<code>(Corrected H * scaleValue / 60)</code>',
 				', where <code>',
 						'scaleValue = ', calculator.scaleValue(reading).toFixed(4),
 				'</code>'].join('');

--- a/test/spec/MagnetometerOrdinatesViewTest.js
+++ b/test/spec/MagnetometerOrdinatesViewTest.js
@@ -187,7 +187,7 @@ define([
 			it('updates view elements for scaleValue', function () {
 				expect(view._scaleValue.textContent).to.equal(
 					'Ordinate Mean D is calculated using ' +
-					'(Corrected F * scaleValue / 60), where scaleValue = ' +
+					'(Corrected H * scaleValue / 60), where scaleValue = ' +
 					format4(14));
 			});
 


### PR DESCRIPTION
This equation may seem confusing since behind the scenes we actually have Ordinate Mean D = **dComputed** = eMean * scaleValue / 60.0, then multiply that by 60.0 since everything is stored in degrees, to get minutes for display.
  * Where **eMean** is the average of the 4 'e' values from the real-time data for the entered West_Up, West_Down, East_Up and East_Down times.
  * And where **scaleValue** = 3437.7468 / absoluteH.
    * Where **absoluteH** = horizontalComponent = correctedF * COS(inclination).
      * Where **corrected F** = fMean + pierCorrection.
        * Where **fMean** is the average of the 4 'f' values from the real-time data for the entered South_Down, North_Up, South_Up and North_Down times.
        * And where **pierCorrection** is defined for a particular pier at a particular observatory in nT.
      * And where **inclination** = ((southDown + northUp) - (southUp + northDown) + 360.0) / 4.0.
        * Where southDown, northUp, southUp and northDown are entered angels in degrees.

Which would mean that dComputed is actually eMean * 3437.7468 * COS(inclination) / (correctedF)...

But it actually is confusing and should maybe be double/triple-checked at some point. Also, according to Bill Worthington, this is now the correct way to show the equation to the user. (Corrected H * scaleValue / 60)