### PR TITLE
Gmp 306

### DIFF
--- a/src/htdocs/js/geomag/Observation.js
+++ b/src/htdocs/js/geomag/Observation.js
@@ -19,7 +19,7 @@ var _DEFAULTS = {
   'elect_temperature': null,
   'flux_temperature': null,
   'proton_temperature': null,
-  'outside_temperature': null,
+  'outside_temperature':null,
   'reviewed': 'N',
   'annotation': null,
   'readings': null

--- a/src/htdocs/js/geomag/ObservationSummaryView.js
+++ b/src/htdocs/js/geomag/ObservationSummaryView.js
@@ -352,34 +352,36 @@ var ObservationSummaryView = function (options) {
         reviewer = _observation.get('reviewer_user_id'),
         electTemp = _observation.get('elect_temperature'),
         fluxgateTemp = _observation.get('flux_temperature'),
+        pierTemp = _observation.get('pier_temperature'),
         protonTemp = _observation.get('proton_temperature'),
         outsideTemp = _observation.get('outside_temperature');
 
-    _this._pierTemperature.innerHTML =
-        Format.celsius(_observation.get('pier_temperature'),1);
+    if (pierTemp !== null) {
+      _pierTemperature.innerHTML = Format.celsius(pierTemp,1);
+    }
     if (electTemp !== null) {
-      _this._electronicsTemperature.innerHTML = Format.celsius(electTemp,1);
+      _electronicsTemperature.innerHTML = Format.celsius(electTemp,1);
     } else {
-      _this._electronicsTemperature.innerHTML = 'elec temp';
+      _electronicsTemperature.innerHTML = 'elec temp';
     }
     if (fluxgateTemp !== null) {
-      _this._fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
+      _fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
     } else {
-      _this._fluxgateTemperature.innerHTML = 'flux temp';
+      _fluxgateTemperature.innerHTML = 'flux temp';
     }
     if (protonTemp !== null) {
-      _this._protonTemperature.innerHTML = Format.celsius(protonTemp,1);
+      _protonTemperature.innerHTML = Format.celsius(protonTemp,1);
     }
     else {
-      _this._protonTemperature.innerHTML = 'prot temp';
+      _protonTemperature.innerHTML = 'prot temp';
     }
     if (outsideTemp !== null) {
-      _this._outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
+      _outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
     }
     else {
-      _this._outsideTemperature.innerHTML = 'outs temp';
+      _outsideTemperature.innerHTML = 'outs temp';
     }
-    _this._remarks.innerHTML = _observation.get('annotation');
+    _remarks.innerHTML = _observation.get('annotation');
 
     if (reviewed === 'Y' && reviewer) {
       // set reviewer to reviwer_user_id while fetching the user name.

--- a/src/htdocs/js/geomag/ObservationSummaryView.js
+++ b/src/htdocs/js/geomag/ObservationSummaryView.js
@@ -356,31 +356,11 @@ var ObservationSummaryView = function (options) {
         protonTemp = _observation.get('proton_temperature'),
         outsideTemp = _observation.get('outside_temperature');
 
-    if (pierTemp !== null) {
-      _pierTemperature.innerHTML = Format.celsius(pierTemp,1);
-    }
-    if (electTemp !== null) {
-      _electronicsTemperature.innerHTML = Format.celsius(electTemp,1);
-    } else {
-      _electronicsTemperature.innerHTML = 'elec temp';
-    }
-    if (fluxgateTemp !== null) {
-      _fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
-    } else {
-      _fluxgateTemperature.innerHTML = 'flux temp';
-    }
-    if (protonTemp !== null) {
-      _protonTemperature.innerHTML = Format.celsius(protonTemp,1);
-    }
-    else {
-      _protonTemperature.innerHTML = 'prot temp';
-    }
-    if (outsideTemp !== null) {
-      _outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
-    }
-    else {
-      _outsideTemperature.innerHTML = 'outs temp';
-    }
+    _pierTemperature.innerHTML = Format.celsius(pierTemp,1);
+    _electronicsTemperature.innerHTML = Format.celsius(electTemp,1);
+    _fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
+    _protonTemperature.innerHTML = Format.celsius(protonTemp,1);
+    _outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
     _remarks.innerHTML = _observation.get('annotation');
 
     if (reviewed === 'Y' && reviewer) {

--- a/src/htdocs/js/geomag/ObservationSummaryView.js
+++ b/src/htdocs/js/geomag/ObservationSummaryView.js
@@ -348,16 +348,51 @@ var ObservationSummaryView = function (options) {
   };
 
   _renderSummaryBottom = function () {
-    _pierTemperature.innerHTML =
+    var reviewed = _observation.get('reviewed'),
+        reviewer = _observation.get('reviewer_user_id'),
+        electTemp = _observation.get('elect_temperature'),
+        fluxgateTemp = _observation.get('flux_temperature'),
+        protonTemp = _observation.get('proton_temperature'),
+        outsideTemp = _observation.get('outside_temperature');
+
+    _this._pierTemperature.innerHTML =
         Format.celsius(_observation.get('pier_temperature'),1);
-    _electronicsTemperature.innerHTML =
-        Format.celsius(_observation.get('elect_temperature'),1);
-    _fluxgateTemperature.innerHTML =
-        Format.celsius(_observation.get('flux_temperature'),1);
-    _protonTemperature.innerHTML =
-        Format.celsius(_observation.get('proton_temperature'),1);
-    _outsideTemperature.innerHTML =
-        Format.celsius(_observation.get('outside_temperature'),1);
+    if (electTemp !== null) {
+      _this._electronicsTemperature.innerHTML = Format.celsius(electTemp,1);
+    } else {
+      _this._electronicsTemperature.innerHTML = 'elec temp';
+    }
+    if (fluxgateTemp !== null) {
+      _this._fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
+    } else {
+      _this._fluxgateTemperature.innerHTML = 'flux temp';
+    }
+    if (protonTemp !== null) {
+      _this._protonTemperature.innerHTML = Format.celsius(protonTemp,1);
+    }
+    else {
+      _this._protonTemperature.innerHTML = 'prot temp';
+    }
+    if (outsideTemp !== null) {
+      _this._outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
+    }
+    else {
+      _this._outsideTemperature.innerHTML = 'outs temp';
+    }
+    _this._remarks.innerHTML = _observation.get('annotation');
+
+    if (reviewed === 'Y' && reviewer) {
+      // set reviewer to reviwer_user_id while fetching the user name.
+      _checkedBy.innerHTML = reviewer;
+
+      _userFactory.get({
+        data: {'id': reviewer},
+        success: function (data) {
+          // replace reviwer_user_id with user name once it is returned.
+          _checkedBy.innerHTML = data.name;
+        }
+      });
+    }
   };
 
   _renderVerticalIntensitySummaryView = function () {

--- a/src/htdocs/js/geomag/ObservationSummaryView.js
+++ b/src/htdocs/js/geomag/ObservationSummaryView.js
@@ -348,9 +348,7 @@ var ObservationSummaryView = function (options) {
   };
 
   _renderSummaryBottom = function () {
-    var reviewed = _observation.get('reviewed'),
-        reviewer = _observation.get('reviewer_user_id'),
-        electTemp = _observation.get('elect_temperature'),
+    var electTemp = _observation.get('elect_temperature'),
         fluxgateTemp = _observation.get('flux_temperature'),
         pierTemp = _observation.get('pier_temperature'),
         protonTemp = _observation.get('proton_temperature'),
@@ -361,20 +359,6 @@ var ObservationSummaryView = function (options) {
     _fluxgateTemperature.innerHTML = Format.celsius(fluxgateTemp,1);
     _protonTemperature.innerHTML = Format.celsius(protonTemp,1);
     _outsideTemperature.innerHTML = Format.celsius(outsideTemp,1);
-    _remarks.innerHTML = _observation.get('annotation');
-
-    if (reviewed === 'Y' && reviewer) {
-      // set reviewer to reviwer_user_id while fetching the user name.
-      _checkedBy.innerHTML = reviewer;
-
-      _userFactory.get({
-        data: {'id': reviewer},
-        success: function (data) {
-          // replace reviwer_user_id with user name once it is returned.
-          _checkedBy.innerHTML = data.name;
-        }
-      });
-    }
   };
 
   _renderVerticalIntensitySummaryView = function () {

--- a/src/htdocs/js/geomag/ObservationView.js
+++ b/src/htdocs/js/geomag/ObservationView.js
@@ -250,6 +250,41 @@ var ObservationView = function (options) {
         });
       }
     });
+
+    // request realtime temperature data
+    if (_observation.get('outside_temperature') === null &&
+          _observation.get('proton_temperature') === null &&
+          _observation.get('elect_temperature') === null &&
+          _observation.get('flux_temperature') === null ) {
+      _realtimeDataFactory.getRealtimeTemperatureData({
+        starttime: starttime,
+        endtime: endtime,
+        success: function (realtimeData) {
+          var averageTime,
+              minuteTime,
+              values;
+          // just get the average time
+          averageTime = Math.floor((starttime + endtime) / 2.0);
+          // temperature data is minute data.
+          minuteTime = averageTime - averageTime % 60;
+          // realtimeData values are in milliseconds, convert seconds to ms.
+          values = realtimeData.getValues(minuteTime*1000);
+          if (values.TO !== undefined) {
+            _observation.set({'outside_temperature':values.TO});
+          }
+          if (values.TP !== undefined) {
+            _observation.set({'proton_temperature':values.TP});
+          }
+          if (values.TE !== undefined) {
+            _observation.set({'elect_temperature':values.TE});
+          }
+          if (values.TF !== undefined) {
+            _observation.set({'flux_temperature':values.TF});
+          }
+        }
+      });
+    }
+
   };
 
   _onChange = function () {

--- a/src/htdocs/js/geomag/ObservationView.js
+++ b/src/htdocs/js/geomag/ObservationView.js
@@ -252,10 +252,6 @@ var ObservationView = function (options) {
     });
 
     // request realtime temperature data
-    if (_observation.get('outside_temperature') === null &&
-          _observation.get('proton_temperature') === null &&
-          _observation.get('elect_temperature') === null &&
-          _observation.get('flux_temperature') === null ) {
       _realtimeDataFactory.getRealtimeTemperatureData({
         starttime: starttime,
         endtime: endtime,
@@ -283,7 +279,6 @@ var ObservationView = function (options) {
           }
         }
       });
-    }
 
   };
 

--- a/src/htdocs/js/geomag/RealtimeDataFactory.js
+++ b/src/htdocs/js/geomag/RealtimeDataFactory.js
@@ -13,7 +13,8 @@ var _DEFAULTS = {
   'starttime': null,
   'endtime': null,
   'channels': ['H','E','Z','F'],
-  'freq': 'seconds'
+  'freq': 'seconds',
+  'temperatureChannels': ['TO', 'TP', 'TE', 'TF']
 };
 
 
@@ -73,6 +74,16 @@ var RealtimeDataFactory = function (options) {
         _options.success(RealtimeData(data));
       }
     });
+  };
+
+  _this.getRealtimeTemperatureData = function (options) {
+    if (options.channels === undefined ){
+      options.channels = _DEFAULTS.temperatureChannels;
+    }
+    if (options.freq === undefined) {
+      options.freq = 'minutes';
+    }
+    _this.getRealtimeData(options);
   };
 
 


### PR DESCRIPTION
Requires GMP-441 to be rolled to production to not get an error.   But when the config for get_geomag_data includes the temperature channels,  then the error disappears,  as nulls are passed back,  as expected. 
We will now be seeing temperature data on saved files that Eddie has loaded,  as those files had temperature data in them.  