### PR TITLE
Rewrite to use Small Angle or Trig.

### DIFF
--- a/src/htdocs/js/geomag/BaselineCalculator.js
+++ b/src/htdocs/js/geomag/BaselineCalculator.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var Util = require('util/Util');
+
+var _DEFAULTS = {
+  smallAngleApproximation: false
+};
+
 var getScaleValueCoefficient = function () {
   return 3437.7468;
 };
@@ -7,10 +13,10 @@ var getScaleValueCoefficient = function () {
 var _SCALE_VALUE_COEFFICIENT = getScaleValueCoefficient();
 
 
-var BaselineCalculator = function () {
+var BaselineCalculator = function (options) {
   var _this;
 
-  _this = {};
+  _this = Util.extend({}, _DEFAULTS, options);
 
   /**
    * D Baseline
@@ -28,12 +34,44 @@ var BaselineCalculator = function () {
    * Computed D
    *
    * @param meanE {Number} nT
-   * @param scaleValue {Number} No units
+   * @param horizontalComponent {Number} nT
    *
    * @return {Number} Decimal degrees
    */
-  _this.dComputed = function (eMean, scaleValue) {
+  _this.dComputed = function (eMean, horizontalComponent) {
+    if (_this.smallAngleApproximation) {
+      return _this.dComputedSmallAngle(eMean, horizontalComponent);
+    } else {
+      return _this.dComputedTan(eMean, horizontalComponent);
+    }
+  };
+
+  /**
+   * Computed D Small Angle
+   *    Computed D using the small angle approximation
+   *
+   * @param meanE {Number} nT
+   * @param horizontalComponent {Number} nT
+   *
+   * @return {Number} Decimal degrees
+   */
+  _this.dComputedSmallAngle = function (eMean, horizontalComponent) {
+    var scaleValue;
+    scaleValue = _this.scaleValue(horizontalComponent);
     return (eMean * scaleValue / 60.0);
+  };
+
+  /**
+   * Computed D Tangent
+   *    Computed D using trig.
+   *
+   * @param meanE {Number} nT
+   * @param horizontalComponent {Number} nT
+   *
+   * @return {Number} Decimal degrees
+   */
+  _this.dComputedTan = function (eMean, horizontalComponent) {
+    return Math.atan2(eMean, horizontalComponent) * 180 / Math.PI;
   };
 
   /**
@@ -52,12 +90,47 @@ var BaselineCalculator = function () {
    * E Baseline
    *
    * @param dBaseline {Number} Decimal degrees
-   * @param scaleValue {Number}
+   * @param horizontalComponent {Number} nT
    *
    * @return {Number} nT
    */
-  _this.eBaseline = function (dBaseline, scaleValue) {
-    return (dBaseline * 60.0 / scaleValue);
+  _this.eBaseline = function (dBaseline, horizontalComponent) {
+    if (_this.smallAngleApproximation) {
+      return _this.eBaselineSmallAngle(dBaseline,
+          horizontalComponent);
+    } else {
+      return _this.eBaselineTan(dBaseline, horizontalComponent);
+    }
+  };
+
+  /**
+   * E Baseline Small Angle Approximation.
+   *    Calculates E Baseline using the Small Angle Approximation.
+   *
+   * @param dBaseline {Number} Decimal degrees
+   * @param horizontalComponent {Number} nT
+   *
+   * @return {Number} nT
+   */
+  _this.eBaselineSmallAngle = function (dBaseline, horizontalComponent) {
+    return (dBaseline * 60.0 / _this.scaleValue(horizontalComponent));
+  };
+
+    /**
+   * E Baseline Tangent
+   *  Calculates the E Baseline using trig.
+   *
+   * @param dBaseline {Number} Decimal degrees
+   * @param horizontalComponent {Number} nT
+   *
+   * @return {Number} nT
+   */
+  _this.eBaselineTan = function (dBaseline, horizontalComponent) {
+    var dBaselineRadian;
+
+    dBaselineRadian = _this.toRadians(dBaseline / 60.0);
+    return (Math.tan(dBaselineRadian) *
+        horizontalComponent) * 60.0;
   };
 
   /**
@@ -83,6 +156,15 @@ var BaselineCalculator = function () {
    */
   _this.geographicMeridian = function (markUp1, markUp2, trueAzimuthMark) {
     return (_this.mean(markUp1, markUp2) - trueAzimuthMark);
+  };
+
+  /**
+   * Get Small Angle Approximation
+   *
+   * @return {binary} Whether we are using the small angle approximation.
+   */
+  _this.getSmallAngleApproximation = function () {
+    return _this.smallAngleApproximation;
   };
 
   /**
@@ -229,6 +311,10 @@ var BaselineCalculator = function () {
     }
 
     return (_SCALE_VALUE_COEFFICIENT / absoluteH);
+  };
+
+  _this.setSmallAngleApproximation = function(smallAngleApproximation) {
+    _this.smallAngleApproximation = smallAngleApproximation;
   };
 
   /**

--- a/src/htdocs/js/geomag/BaselineCalculator.js
+++ b/src/htdocs/js/geomag/BaselineCalculator.js
@@ -113,7 +113,7 @@ var BaselineCalculator = function (options) {
    * @return {Number} nT
    */
   _this.eBaselineSmallAngle = function (dBaseline, horizontalComponent) {
-    return (dBaseline * 60.0 / _this.scaleValue(horizontalComponent));
+    return (dBaseline / _this.scaleValue(horizontalComponent));
   };
 
     /**
@@ -130,7 +130,7 @@ var BaselineCalculator = function (options) {
 
     dBaselineRadian = _this.toRadians(dBaseline / 60.0);
     return (Math.tan(dBaselineRadian) *
-        horizontalComponent) * 60.0;
+        horizontalComponent);
   };
 
   /**

--- a/src/htdocs/js/geomag/ObservationBaselineCalculator.js
+++ b/src/htdocs/js/geomag/ObservationBaselineCalculator.js
@@ -9,6 +9,7 @@ var BaselineCalculator = require('geomag/BaselineCalculator'),
 var _DEFAULTS = {
   // model options
   pierCorrection: 0,
+  smallAngleApproximation: false,
   trueAzimuthOfMark: 0
 };
 
@@ -33,6 +34,7 @@ var ObservationBaselineCalculator = function (options) {
     _initialize = function (options) {
       // keep calculator outside model
       _calculator = options.calculator || BaselineCalculator();
+      _calculator.setSmallAngleApproximation(_this.smallAngleApproximation);
     };
 
   /**
@@ -396,6 +398,11 @@ var ObservationBaselineCalculator = function (options) {
     return _calculator.scaleValue(
         _this.horizontalComponent(reading)
     );
+  };
+
+  _this.setSmallAngleApproximation = function(smallAngleApproximation) {
+    _this.smallAngleApproximation = smallAngleApproximation;
+    _calculator.setSmallAngleApproximation(_this.smallAngleApproximation);
   };
 
   /**

--- a/src/htdocs/js/geomag/ObservationBaselineCalculator.js
+++ b/src/htdocs/js/geomag/ObservationBaselineCalculator.js
@@ -59,7 +59,7 @@ var ObservationBaselineCalculator = function (options) {
   _this.dComputed = function (reading) {
     return _calculator.dComputed(
         _this.meanE(reading),
-        _this.scaleValue(reading)
+        _this.horizontalComponent(reading)
     );
   };
 
@@ -89,7 +89,7 @@ var ObservationBaselineCalculator = function (options) {
   _this.eBaseline = function (reading) {
     return _calculator.eBaseline(
         _this.dBaseline(reading),
-        _this.scaleValue(reading)
+        _this.horizontalComponent(reading)
     ); //
   };
 

--- a/test/spec/BaselineCalculatorTest.js
+++ b/test/spec/BaselineCalculatorTest.js
@@ -638,41 +638,66 @@ describe('Unit tests for BaselineCalculator', function () {
 
 
   describe('dComputed()', function () {
+    var calcSAA,
+        calcTan;
+    calcSAA = BaselineCalculator({smallAngleApproximation:true});
+    calcTan = BaselineCalculator({smallAngleApproximation:false});
 
     it('computes correctly', function () {
       var eAbsolute = 1.0,
-          scaleValue = 1.0,
+          scaleValue = calcSAA.scaleValue(1.0),
           expected = 1.0/60.0;
 
-      expect(calc.dComputed(eAbsolute, scaleValue)).to.equal(expected);
+      expect(calcSAA.dComputed(eAbsolute, scaleValue)).to.be.closeTo(expected,
+          0.000001);
     });
 
     it('computes correctly with data from BDT20131651602.bns', function () {
       var meanE = -155.48,          // -155.48
-          scaleValue = 0.164946633, // 0.1649
+          scaleValue = calcSAA.scaleValue(0.164946633), // 0.1649
           expected = -0.427431709;  // -25.65 converted to degrees
 
-      expect(calc.dComputed(
+      expect(calcSAA.dComputed(
           meanE, scaleValue)).to.be.closeTo(expected, 0.000001);
     });
 
     it('computes correctly with data from CMO20131651602.bns', function () {
       var meanE = -48.66,           // -48.66
-          scaleValue = 0.274863402, // 0.2749
+          scaleValue = calcSAA.scaleValue(0.274863402), // 0.2749
           expected = -0.222914219;  // -13.37 converted to degrees
 
-      expect(calc.dComputed(
+      expect(calcSAA.dComputed(
           meanE, scaleValue)).to.be.closeTo(expected, 0.000001);
     });
 
     it('computes correctly with data from FRN20130311611.bns', function () {
       var meanE = -311.22,          // -311.22
-          scaleValue = 0.146384584, // 0.1464
+          scaleValue = calcSAA.scaleValue(0.146384584), // 0.1464
           expected = -0.759296836;  // -45.56 converted to degrees
 
-      expect(calc.dComputed(
+      expect(calcSAA.dComputed(
           meanE, scaleValue)).to.be.closeTo(expected, 0.000001);
     });
+
+    it('computes correctly using tangeant', function () {
+      var eAbsolute = 1.0,
+          horizontalComponent = 1.0,
+          expected = 45.0;
+
+      expect(calcTan.dComputed(eAbsolute, horizontalComponent)).to.be.closeTo(
+        expected, 0.000001);
+    });
+
+    it('computes correctly with data from FRN20130311611.bns using tangeant',
+      function () {
+        var meanE = -311.22,          // -311.22
+            scaleValue = calcSAA.scaleValue(0.146384584), // 0.1464
+            expected = -0.759296836;  // -45.56 converted to degrees
+
+        expect(calcTan.dComputed(
+            meanE, scaleValue)).to.be.closeTo(expected, 0.0001);
+    });
+
 
   }); // END :: computedE
 
@@ -745,39 +770,43 @@ describe('Unit tests for BaselineCalculator', function () {
   }); // END :: baselineZ
 
   describe('eBaseline()', function () {
+    var calcSAA,
+        calcTan;
+    calcSAA = BaselineCalculator({smallAngleApproximation:true});
+    calcTan = BaselineCalculator({smallAngleApproximation:false});
 
     it('computes correctly', function () {
       var dBaseline = 10.0,
-          scaleValue = 10.0,
+          scaleValue = calcSAA.scaleValue(10.0),
           expected = 60.0;
 
-      expect(calc.eBaseline(dBaseline, scaleValue)).to.equal(expected);
+      expect(calcSAA.eBaseline(dBaseline, scaleValue)).to.equal(expected);
     });
 
     it('computes correctly with data from BDT20131651602.bns', function () {
       var dBaseline = 9.494931709,  // 569.69 converted to degrees
-          scaleValue = 0.164946633, // 0.1649
+          scaleValue = calcSAA.scaleValue(0.164946633), // 0.1649
           expected = 3453.819528;   // 3453.78
 
-      expect(calc.eBaseline(dBaseline,
+      expect(calcSAA.eBaseline(dBaseline,
           scaleValue)).to.be.closeTo(expected, 0.0001);
     });
 
     it('computes correctly with data from CMO20131651602.bns', function () {
       var dBaseline = 19.51971422,   // 1171.18 converted to degrees
-          scaleValue = 0.274863402,  // 0.2749
+          scaleValue = calcSAA.scaleValue(0.274863402),  // 0.2749
           expected = 4260.963249;    // 4260.95
 
-      expect(calc.eBaseline(dBaseline,
+      expect(calcSAA.eBaseline(dBaseline,
           scaleValue)).to.be.closeTo(expected, 0.0001);
     });
 
     it('computes correctly with data from FRN20130311611.bns', function () {
       var dBaseline = 14.10349684,  // 846.21 converted to degrees
-          scaleValue = 0.146384584, // 0.1464
+          scaleValue = calcSAA.scaleValue(0.146384584), // 0.1464
           expected = 5780.730377;   // 5780.73
 
-      expect(calc.eBaseline(dBaseline,
+      expect(calcSAA.eBaseline(dBaseline,
           scaleValue)).to.be.closeTo(expected, 0.0001);
     });
 

--- a/test/spec/BaselineCalculatorTest.js
+++ b/test/spec/BaselineCalculatorTest.js
@@ -780,7 +780,8 @@ describe('Unit tests for BaselineCalculator', function () {
           scaleValue = calcSAA.scaleValue(10.0),
           expected = 60.0;
 
-      expect(calcSAA.eBaseline(dBaseline, scaleValue)).to.equal(expected);
+      expect(calcSAA.eBaseline(dBaseline, scaleValue) * 60.0).to.equal(
+          expected);
     });
 
     it('computes correctly with data from BDT20131651602.bns', function () {
@@ -789,7 +790,7 @@ describe('Unit tests for BaselineCalculator', function () {
           expected = 3453.819528;   // 3453.78
 
       expect(calcSAA.eBaseline(dBaseline,
-          scaleValue)).to.be.closeTo(expected, 0.0001);
+          scaleValue) * 60.0).to.be.closeTo(expected, 0.0001);
     });
 
     it('computes correctly with data from CMO20131651602.bns', function () {
@@ -798,7 +799,7 @@ describe('Unit tests for BaselineCalculator', function () {
           expected = 4260.963249;    // 4260.95
 
       expect(calcSAA.eBaseline(dBaseline,
-          scaleValue)).to.be.closeTo(expected, 0.0001);
+          scaleValue) * 60.0).to.be.closeTo(expected, 0.0001);
     });
 
     it('computes correctly with data from FRN20130311611.bns', function () {
@@ -807,7 +808,7 @@ describe('Unit tests for BaselineCalculator', function () {
           expected = 5780.730377;   // 5780.73
 
       expect(calcSAA.eBaseline(dBaseline,
-          scaleValue)).to.be.closeTo(expected, 0.0001);
+          scaleValue) * 60.0).to.be.closeTo(expected, 0.0001);
     });
 
   });

--- a/test/spec/MagnetometerOrdinatesViewTest.js
+++ b/test/spec/MagnetometerOrdinatesViewTest.js
@@ -158,7 +158,7 @@ describe('Unit tests for MagnetometerOrdinatesView', function () {
       expect(view._hBaseline.innerHTML).to.equal(Format.nanoteslas(9));
     });
     it('updates view elements for eBaseline', function () {
-      expect(view._eBaseline.innerHTML).to.equal(Format.nanoteslas(10));
+      expect(view._eBaseline.innerHTML).to.equal(Format.nanoteslas(10 * 60.0));
     });
     it('updates view elements for dBaseline', function () {
       expect(view._dBaseline.innerHTML).to.equal(Format.minutes(11*60));

--- a/test/spec/ObservationBaselineCalculatorTest.js
+++ b/test/spec/ObservationBaselineCalculatorTest.js
@@ -347,7 +347,7 @@ describe('Unit tests for ObservationBaselineCalculator', function () {
 
     it('computes correctly with data from BOU20132861836.bns', function () {
       var expected = 3557.5945472773902;   // 3556.6245477416474
-      expect(calc.eBaseline(READING)).to.be.closeTo(expected, 0.1);
+      expect(calc.eBaseline(READING) * 60.0).to.be.closeTo(expected, 0.1);
     });
 
   }); // END :: eBaseline

--- a/test/spec/ObservationBaselineCalculatorTest.js
+++ b/test/spec/ObservationBaselineCalculatorTest.js
@@ -319,7 +319,7 @@ describe('Unit tests for ObservationBaselineCalculator', function () {
 
     it('computes correctly with data from BOU20132861836.bns', function () {
       var expected = 9.780333333333335;  // 586.66 min, converted to degrees
-      expect(calc.dBaseline(READING)).to.be.closeTo(expected, 0.0001);
+      expect(calc.dBaseline(READING)).to.be.closeTo(expected, 0.001);
     });
 
   }); // END :: dBaseline


### PR DESCRIPTION
fixes #246 

This is step one.  Will change the interface to display both small angle and trig for admins, so the users can test on ehpdevel.   Current default is to use trig,  as indicated by Josh, and Tim during weekly meeting.